### PR TITLE
Fix #291 Member Access on Const Object

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -39,14 +39,14 @@
   <script src="https://cdn.jsdelivr.net/npm/js-cookie@2/src/js.cookie.min.js"></script>
 
   <!-- Custom CSS -->
-  <link rel="stylesheet" href="css/buttons.css?v=26">
-  <link rel="stylesheet" href="css/main.css?v=26">
-  <link rel="stylesheet" href="css/code.css?v=26">
-  <link rel="stylesheet" href="css/exercises.css?v=26">
-  <link rel="stylesheet" href="css/frontend.css?v=26">
+  <link rel="stylesheet" href="css/buttons.css?v=30">
+  <link rel="stylesheet" href="css/main.css?v=30">
+  <link rel="stylesheet" href="css/code.css?v=30">
+  <link rel="stylesheet" href="css/exercises.css?v=30">
+  <link rel="stylesheet" href="css/frontend.css?v=30">
 
   <!-- Main Script -->
-  <script src="js/main.js?v=26"></script>
+  <script src="js/main.js?v=30"></script>
 
 </head>
 

--- a/src/js/core/FunctionCallExpression.ts
+++ b/src/js/core/FunctionCallExpression.ts
@@ -76,10 +76,6 @@ export class FunctionCallExpression extends Expression<FunctionCallExpressionAST
 
         this.valueCategory = returnType instanceof ReferenceType ? "lvalue" : "prvalue";
 
-        // let staticReceiver: ObjectEntity<CompleteClassType> | undefined;
-        // if (operand instanceof DotExpression) {
-        //     staticReceiver = operand.functionCallReceiver;
-        // }
         // If we get to here, we don't attach the args directly since they will be attached under the function call.
         this.attach(this.call = new FunctionCall(context, operand.entity, args, operand.context.contextualReceiverType));
     }

--- a/src/js/core/declarations.ts
+++ b/src/js/core/declarations.ts
@@ -1668,8 +1668,8 @@ export class FunctionDefinition extends BasicCPPConstruct<FunctionContext, Funct
         // Create implementation and body block (before params and body statements added yet)
         let receiverType: CompleteClassType | undefined;
         if (declaration.isMemberFunction) {
-            assert(declaration.context.containingClass?.isComplete(), "Member function definitions may not be compiled until their containing class definition has been completed.");
-            receiverType = declaration.context.containingClass.type;
+            assert(declaration.type.receiverType?.isComplete(), "Member function definitions may not be compiled until their containing class definition has been completed.");
+            receiverType = declaration.type.receiverType;
         }
         
         let functionContext = createFunctionContext(context, declaration.declaredEntity, receiverType);

--- a/src/js/core/entities.ts
+++ b/src/js/core/entities.ts
@@ -1298,40 +1298,6 @@ export class BaseSubobjectEntity extends CPPEntity<CompleteClassType> implements
 }
 
 
-
-export class MemberAccessEntity<T extends CompleteObjectType = CompleteObjectType> extends CPPEntity<T> implements ObjectEntity<T> {
-    public readonly variableKind = "object";
-
-    public readonly containingEntity: ObjectEntity<CompleteClassType>;
-    public readonly name: string;
-
-    constructor(containingEntity: ObjectEntity<CompleteClassType>, type: T, name: string) {
-        super(type);
-        this.containingEntity = containingEntity;
-        this.name = name;
-    }
-
-    public runtimeLookup(rtConstruct: RuntimeConstruct) {
-        // Cast below should be <CPPObject<T>>, NOT MemberSubobject<T>.
-        // See return type and documentation for getMemberSubobject()
-        return <CPPObject<T>>this.containingEntity.runtimeLookup(rtConstruct).getMemberObject(this.name);
-    }
-
-    public isTyped<NarrowedT extends CompleteObjectType>(predicate: (t:CompleteObjectType) => t is NarrowedT) : this is MemberAccessEntity<NarrowedT>;
-    public isTyped<NarrowedT extends Type>(predicate: (t:Type) => t is NarrowedT) : this is never;
-    public isTyped<NarrowedT extends CompleteObjectType>(predicate: (t:CompleteObjectType) => t is NarrowedT) : this is MemberAccessEntity<NarrowedT> {
-        return predicate(this.type);
-    }
-
-    public describe() {
-        let containingObjectDesc = this.containingEntity.describe();
-        return {
-            name: containingObjectDesc.name + "." + this.name,
-            message: "the " + this.name + " member of " + containingObjectDesc.message
-        };
-    }
-}
-
 // export class BaseClassEntity extends CPPEntity<ClassType> implements ObjectEntity<ClassType> {
 //     protected static readonly _name = "BaseClassEntity";
 //     // storage: "none",

--- a/src/js/core/errors.ts
+++ b/src/js/core/errors.ts
@@ -862,8 +862,8 @@ export const CPPError = {
             decrement_bool_prohibited: function (construct: TranslationUnitConstruct) {
                 return new CompilerNote(construct, NoteKind.ERROR, "expr.postfixIncrement.decrement_bool_prohibited", "The -- operator may not be used on an object of boolean type.");
             },
-            const_prohibited: function (construct: TranslationUnitConstruct) {
-                return new CompilerNote(construct, NoteKind.ERROR, "expr.postfixIncrement.const_prohibited", "The -- operator may not be used on a const object.");
+            const_prohibited: function (construct: TranslationUnitConstruct, operator: string) {
+                return new CompilerNote(construct, NoteKind.ERROR, "expr.postfixIncrement.const_prohibited", "The " + operator + " operator may not be used on a const object.");
             }
         },
         functionCall: {

--- a/src/js/core/types.ts
+++ b/src/js/core/types.ts
@@ -1219,7 +1219,7 @@ export class ReferenceType<RefTo extends PotentiallyCompleteObjectType = Potenti
     }
 
     public _cvQualifiedImpl(isConst: boolean, isVolatile: boolean) {
-        return new ReferenceType(this.refTo);
+        return new ReferenceType(this.refTo); // does nothing, reference can't be cv qualified
     }
 
 }


### PR DESCRIPTION
This PR fixes #291.

It specifically fixes two problems that were causing the complier to not respect constness via member access:
 - `FunctionDefinition` was creating a function context using the type of the containing class as the type of the receiver. But, this fails to take into account any constness present on the signature of that function. So the contextual receiver object never carried a const. Now the type of the receiver for the function context is taken from the receiver type for the declared function type, which is correct.
 - `DotExpression`, `ArrowExpression`, and `IdentifierExpression` - the three expressions that can provide member access - failed to take into account whether const should be applied due to member access on a const receiver object (and the entities used to represent the members accessed have no mechanism for applying this const or not). Now, those objects do account for this.

We also clean up a bunch of random stuff, including an old unused `MemberAccessEntity`, some unused properties on various classes (e.g. `staticReceiver`, `functionCallReceiver`), and some random old commented code for dot operators.

Also fixes a miscellaneous bug that I noticed in the error messages for postfix operators.