### PR TITLE
Fix #299

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -782,6 +782,10 @@ ul.codeStack li{
 	text-overflow: ellipsis;
 }
 
+.lobster-compilation-pane .compilation-notes-list .list-group-item {
+	overflow-wrap: break-word;
+}
+
 .lobster-save-button-icon {
 	font-size: 1.5em;
 	line-height: 50%;


### PR DESCRIPTION
Super easy fix for #299 .

Just added css to make sure too-long error identifiers are being broken in the compilation notes pane.

 
<img width="417" alt="Screenshot 2022-02-28 at 6 51 43 PM" src="https://user-images.githubusercontent.com/31768361/156078447-b3a75814-bde5-4c02-87eb-74214253e2cb.png">
