### PR TITLE
Add #include <string> to default lobster

### DIFF
--- a/public/exercise-test.html
+++ b/public/exercise-test.html
@@ -45,6 +45,7 @@
     <!-- <div class="lobster-ex-project-name">ch16_ex_printDoubled</div> -->
     <div class="lobster-ex-init-code">
 #include &lt;iostream&gt;
+#include &lt;string&gt;
 int main() {
   cout &lt;&lt; "Hello world!" &lt;&lt; endl;
 }


### PR DESCRIPTION
My students love using lobster to visualize their code at Morehouse college intro to programing. The one issue is on the version of c++ they use the string library is included in iostream and on lobster it is not. They get errors when they try and use strings in their code. It would be great if their working code from elsewhere worked out of the box on lobster. (this doesn't fully solve the issue if they copy and paste their whole file with the include statements and wipe out the default code, but that seems like it would be a bigger change to update the copy of iostream that lobster uses to include string in it the way it is in current c++)